### PR TITLE
Make serviceName check null-safe

### DIFF
--- a/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/AttributesExtractor.java
+++ b/translation-stackdriver/src/main/java/zipkin2/translation/stackdriver/AttributesExtractor.java
@@ -80,7 +80,9 @@ final class AttributesExtractor {
       }
     }
 
-    if (zipkinSpan.localEndpoint() != null && !zipkinSpan.localEndpoint().serviceName().isEmpty()) {
+    if (zipkinSpan.localEndpoint() != null &&
+        zipkinSpan.localEndpoint().serviceName() != null &&
+        !zipkinSpan.localEndpoint().serviceName().isEmpty()) {
       attributes.putAttributeMap(
           kComponentLabelKey, toAttributeValue(zipkinSpan.localEndpoint().serviceName()));
     }


### PR DESCRIPTION
Span object stores `localEndpoint.serviceName` empty string as null so `.isEmpty()` throws NullPointerException.